### PR TITLE
Update to UTF8, reduce number of remote (DB) calls by using upsert

### DIFF
--- a/phpcount.php
+++ b/phpcount.php
@@ -267,7 +267,7 @@ class PHPCount
     
     private static function IDHash($pageID)
     {
-        $visitorID = $_SERVER['REMOTE_ADDR'];
+        $visitorID = $_SERVER['REMOTE_ADDR'] . $_SERVER['HTTP_USER_AGENT'];
         return hash("SHA256", $pageID . $visitorID);
     }
 

--- a/phpcount.sql
+++ b/phpcount.sql
@@ -33,6 +33,11 @@ CREATE TABLE IF NOT EXISTS `hits` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
+-- add primary key
+--
+alter table hits add primary key (pageid, isunique);
+
+--
 -- Dumping data for table `hits`
 --
 

--- a/phpcount.sql
+++ b/phpcount.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS `hits` (
   `isunique` tinyint(1) NOT NULL,
   `hitcount` int(10) unsigned NOT NULL,
   KEY `pageid` (`pageid`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `hits`
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS `nodupes` (
   `ids_hash` char(64) NOT NULL,
   `time` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`ids_hash`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `nodupes`


### PR DESCRIPTION
Small changes to improve performance, and be able to use international URLs.

More specifically I remove the CreateCountsIfNotPresent() method, and use an upsert to either INSERT or UPDATE in one single step in AddCount(). This reduces the number of DB calls, and also removes a race condition, if a page without count is called in parallel (with then two threads possibly trying to insert the same row).

It requires a primary key in the "hits" table though. But that should be ok, as number of rows there is restricted to twice the number of pages in the web site.